### PR TITLE
Read environment variables from kotori-journal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@types/react": "^19.1.7",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
-        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "ink": "^6.0.0",
         "ink-select-input": "^6.2.0",
@@ -2915,17 +2914,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@types/react": "^19.1.7",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
-    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "ink": "^6.0.0",
     "ink-select-input": "^6.2.0",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-import dotenv from 'dotenv'
 import React from 'react'
 import { render } from 'ink'
 import { App } from './components/App.js'
 import { getConfig } from './utils/config.js'
 import { ServerCommand } from './commands/server-command.js'
+import { loadEnvironmentVariables } from './utils/env-loader.js'
 
-// .envファイルから環境変数を読み込み
-dotenv.config()
+// .envファイルと.kotori-journalファイルから環境変数を読み込み
+loadEnvironmentVariables()
 
 const config = getConfig()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type { Plugin } from './models/plugin.js'
 // Utils
 export { getConfig } from './utils/config.js'
 export type { Config } from './utils/config.js'
+export { loadEnvironmentVariables } from './utils/env-loader.js'
 
 // For convenience, users can also import the main services directly
 // Example: import { JournalService, StorageService, ClaudeAIService } from 'kotori-journal'

--- a/src/utils/env-loader.ts
+++ b/src/utils/env-loader.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+/**
+ * 環境変数ファイルの内容をパースして環境変数に設定する
+ * @param content ファイルの内容
+ */
+function parseEnvContent(content: string): void {
+  const lines = content.split('\n')
+
+  for (const line of lines) {
+    const trimmedLine = line.trim()
+
+    // 空行やコメント行をスキップ
+    if (!trimmedLine || trimmedLine.startsWith('#')) {
+      continue
+    }
+
+    // = が含まれていない行をスキップ
+    const equalIndex = trimmedLine.indexOf('=')
+    if (equalIndex === -1 || equalIndex === 0) {
+      continue
+    }
+
+    const key = trimmedLine.substring(0, equalIndex).trim()
+    let value = trimmedLine.substring(equalIndex + 1).trim()
+
+    // クォートを除去
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+
+    // 環境変数に設定（既存の値を上書き）
+    process.env[key] = value
+  }
+}
+
+/**
+ * .envファイルとホームディレクトリの.kotori-journalファイルから環境変数を読み込む
+ * .kotori-journalファイルの変数は.envファイルの変数を上書きする
+ */
+export function loadEnvironmentVariables(): void {
+  // .envファイルを読み込み
+  if (fs.existsSync('.env')) {
+    try {
+      const envContent = fs.readFileSync('.env', 'utf8')
+      parseEnvContent(envContent)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Warning: Failed to read .env file:', error)
+    }
+  }
+
+  // ホームディレクトリの.kotori-journalファイルを読み込み
+  const homeDir = os.homedir()
+  const kotoriJournalPath = path.join(homeDir, '.kotori-journal')
+
+  if (fs.existsSync(kotoriJournalPath)) {
+    try {
+      const kotoriContent = fs.readFileSync(kotoriJournalPath, 'utf8')
+      parseEnvContent(kotoriContent)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Warning: Failed to read .kotori-journal file:', error)
+    }
+  }
+}

--- a/tests/utils/env-loader.test.ts
+++ b/tests/utils/env-loader.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import { loadEnvironmentVariables } from '../../src/utils/env-loader'
+
+// fs.readFileSync をモック
+vi.mock('fs')
+const mockedFs = vi.mocked(fs)
+
+// os.homedir をモック
+vi.mock('os')
+const mockedOs = vi.mocked(os)
+
+describe('loadEnvironmentVariables', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // process.envをクリーンアップ
+    delete process.env.TEST_VAR
+    delete process.env.KOTORI_TEST_VAR
+    delete process.env.ANOTHER_VAR
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should load variables from .env file', () => {
+    const envContent = `
+TEST_VAR=test_value
+KOTORI_TEST_VAR=kotori_value
+# This is a comment
+ANOTHER_VAR=another_value
+`
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '.env'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '.env') {
+        return envContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    loadEnvironmentVariables()
+
+    expect(process.env.TEST_VAR).toBe('test_value')
+    expect(process.env.KOTORI_TEST_VAR).toBe('kotori_value')
+    expect(process.env.ANOTHER_VAR).toBe('another_value')
+  })
+
+  it('should load variables from .kotori-journal file in home directory', () => {
+    const kotoriContent = `
+KOTORI_API_KEY=secret_key
+KOTORI_DEBUG=true
+HOME_VAR=home_value
+`
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/home/user/.kotori-journal'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '/home/user/.kotori-journal') {
+        return kotoriContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    loadEnvironmentVariables()
+
+    expect(process.env.KOTORI_API_KEY).toBe('secret_key')
+    expect(process.env.KOTORI_DEBUG).toBe('true')
+    expect(process.env.HOME_VAR).toBe('home_value')
+  })
+
+  it('should load variables from both .env and .kotori-journal files', () => {
+    const envContent = `TEST_VAR=env_value`
+    const kotoriContent = `KOTORI_VAR=kotori_value`
+
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '.env' || filePath === '/home/user/.kotori-journal'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '.env') {
+        return envContent
+      }
+      if (filePath === '/home/user/.kotori-journal') {
+        return kotoriContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    loadEnvironmentVariables()
+
+    expect(process.env.TEST_VAR).toBe('env_value')
+    expect(process.env.KOTORI_VAR).toBe('kotori_value')
+  })
+
+  it('should handle .kotori-journal variables overriding .env variables', () => {
+    const envContent = `SAME_VAR=env_value`
+    const kotoriContent = `SAME_VAR=kotori_value`
+
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '.env' || filePath === '/home/user/.kotori-journal'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '.env') {
+        return envContent
+      }
+      if (filePath === '/home/user/.kotori-journal') {
+        return kotoriContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    loadEnvironmentVariables()
+
+    expect(process.env.SAME_VAR).toBe('kotori_value')
+  })
+
+  it('should handle files that do not exist gracefully', () => {
+    mockedFs.existsSync.mockReturnValue(false)
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    expect(() => loadEnvironmentVariables()).not.toThrow()
+  })
+
+  it('should handle malformed environment files gracefully', () => {
+    const malformedContent = `
+VALID_VAR=valid_value
+INVALID_LINE_WITHOUT_EQUALS
+=INVALID_EQUALS_AT_START
+ANOTHER_VALID=another_value
+`
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '.env'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '.env') {
+        return malformedContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    expect(() => loadEnvironmentVariables()).not.toThrow()
+    expect(process.env.VALID_VAR).toBe('valid_value')
+    expect(process.env.ANOTHER_VALID).toBe('another_value')
+  })
+
+  it('should handle quoted values correctly', () => {
+    const envContent = `
+QUOTED_VAR="quoted value"
+SINGLE_QUOTED='single quoted'
+MIXED_VAR="value with 'single' quotes"
+`
+    mockedFs.existsSync.mockImplementation(filePath => {
+      return filePath === '.env'
+    })
+    mockedFs.readFileSync.mockImplementation(filePath => {
+      if (filePath === '.env') {
+        return envContent
+      }
+      throw new Error('File not found')
+    })
+    mockedOs.homedir.mockReturnValue('/home/user')
+
+    loadEnvironmentVariables()
+
+    expect(process.env.QUOTED_VAR).toBe('quoted value')
+    expect(process.env.SINGLE_QUOTED).toBe('single quoted')
+    expect(process.env.MIXED_VAR).toBe("value with 'single' quotes")
+  })
+})


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add support for loading environment variables from `~/.kotori-journal` in addition to `.env`, and remove `dotenv` dependency.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
A custom environment variable loader was implemented to handle both `.env` and `~/.kotori-journal` files. Variables in `~/.kotori-journal` take precedence over those in `.env`. This change allowed for the removal of the `dotenv` package, reducing external dependencies.