### PR TITLE
Handle existing data directory scenarios

### DIFF
--- a/src/commands/server-command.ts
+++ b/src/commands/server-command.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process'
 import fs from 'fs/promises'
 import path from 'path'
 import { Config } from '../utils/config.js'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 interface ServerConfig {
   port: number
@@ -190,7 +191,7 @@ export class ServerCommand {
   }
 
   private async ensureDataDir(): Promise<void> {
-    await fs.mkdir(path.dirname(this.pidFile), { recursive: true })
+    await ensureDirectoryExists(path.dirname(this.pidFile))
   }
 
   private showHelp(): void {

--- a/src/services/category-storage.ts
+++ b/src/services/category-storage.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import { CategoryManager } from '../models/category'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 export class CategoryStorage {
   private filePath: string
@@ -10,7 +11,7 @@ export class CategoryStorage {
   }
 
   async save(manager: CategoryManager): Promise<void> {
-    await fs.mkdir(this.dataPath, { recursive: true })
+    await ensureDirectoryExists(this.dataPath)
     const data = JSON.stringify(manager.toJSON(), null, 2)
     await fs.writeFile(this.filePath, data)
   }

--- a/src/services/content-pattern-storage.ts
+++ b/src/services/content-pattern-storage.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { ContentPatternManager } from '../models/content-pattern.js'
 import { ContentPattern } from '../types/content-processing.js'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 export class ContentPatternStorage {
   private filePath: string
@@ -43,7 +44,7 @@ export class ContentPatternStorage {
   async ensureDirectoryExists(): Promise<void> {
     const dir = path.dirname(this.filePath)
     try {
-      await fs.mkdir(dir, { recursive: true })
+      await ensureDirectoryExists(dir)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to create directory:', error)

--- a/src/services/plugin-manager.ts
+++ b/src/services/plugin-manager.ts
@@ -5,6 +5,7 @@ import { Plugin, PluginConfig, PluginSource, PluginContext } from '../models/plu
 import { PluginSourceManager } from './plugin-source-manager'
 import { CommandRegistry } from './command-registry'
 import { Config } from '../utils/config'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 export class PluginManager {
   private plugins: Map<string, Plugin> = new Map()
@@ -175,9 +176,7 @@ export class PluginManager {
     const configPath = this.getPluginConfigPath()
     const configDir = path.dirname(configPath)
 
-    if (!existsSync(configDir)) {
-      await fs.mkdir(configDir, { recursive: true })
-    }
+    await ensureDirectoryExists(configDir)
 
     const data = {
       plugins: Object.fromEntries(this.pluginConfigs),
@@ -227,9 +226,7 @@ export class PluginManager {
       },
 
       async write(key: string, value: string): Promise<void> {
-        if (!existsSync(pluginDataPath)) {
-          await fs.mkdir(pluginDataPath, { recursive: true })
-        }
+        await ensureDirectoryExists(pluginDataPath)
         const filePath = path.join(pluginDataPath, `${key}.json`)
         await fs.writeFile(filePath, value, 'utf-8')
       },

--- a/src/services/plugin-security.ts
+++ b/src/services/plugin-security.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs/promises'
 import { existsSync } from 'fs'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 export class PluginSecurityManager {
   constructor(private dataPath: string) {}
@@ -195,9 +196,7 @@ export class PluginSandbox {
           throw new Error('Storage value too large. Maximum size is 1MB.')
         }
 
-        if (!existsSync(pluginDataPath)) {
-          await fs.mkdir(pluginDataPath, { recursive: true })
-        }
+        await ensureDirectoryExists(pluginDataPath)
         const filePath = path.join(pluginDataPath, `${key}.json`)
         await fs.writeFile(filePath, value, 'utf-8')
       },

--- a/src/services/plugin-source-manager.ts
+++ b/src/services/plugin-source-manager.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs'
 import { Plugin, PluginSource } from '../models/plugin'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 const execAsync = promisify(exec)
 
@@ -102,9 +103,7 @@ export class PluginSourceManager {
   }
 
   private async ensureDir(dirPath: string): Promise<void> {
-    if (!existsSync(dirPath)) {
-      await fs.mkdir(dirPath, { recursive: true })
-    }
+    await ensureDirectoryExists(dirPath)
   }
 
   private async validateLocalPath(pluginPath: string): Promise<void> {

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import * as path from 'path'
 import { JournalEntry } from '../models/journal'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 export interface SearchResult {
   date: string
@@ -13,7 +14,7 @@ export class StorageService {
 
   async saveEntryToTemp(entry: JournalEntry): Promise<void> {
     const tempDir = path.join(this.dataPath, '.temp')
-    await fs.mkdir(tempDir, { recursive: true })
+    await ensureDirectoryExists(tempDir)
 
     const filePath = path.join(tempDir, `${entry.id}.json`)
     await fs.writeFile(filePath, JSON.stringify(entry, null, 2))
@@ -25,7 +26,7 @@ export class StorageService {
     const day = date.getDate().toString().padStart(2, '0')
 
     const reportDir = path.join(this.dataPath, year, month)
-    await fs.mkdir(reportDir, { recursive: true })
+    await ensureDirectoryExists(reportDir)
 
     const reportPath = path.join(reportDir, `${day}.md`)
     const content = this.formatDailyReport(date, entries)

--- a/src/services/token-storage.ts
+++ b/src/services/token-storage.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises'
 import path from 'path'
+import { ensureDirectoryExists } from '../utils/directory.js'
 
 interface TokenData {
   token: string
@@ -33,7 +34,7 @@ export class TokenStorage {
       token,
       createdAt: new Date().toISOString(),
     }
-    await fs.mkdir(this.dataPath, { recursive: true })
+    await ensureDirectoryExists(this.dataPath)
     await fs.writeFile(this.tokenFile, JSON.stringify(data, null, 2))
   }
 

--- a/src/utils/directory.ts
+++ b/src/utils/directory.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from 'fs'
+
+/**
+ * ディレクトリが存在することを確認し、必要に応じて作成する
+ * 既存のディレクトリやシンボリックリンクも適切に処理する
+ */
+export async function ensureDirectoryExists(dirPath: string): Promise<void> {
+  try {
+    const stats = await fs.lstat(dirPath)
+
+    if (stats.isDirectory()) {
+      // 既にディレクトリとして存在している場合はOK
+      return
+    }
+
+    if (stats.isSymbolicLink()) {
+      // シンボリックリンクの場合、リンク先を確認
+      try {
+        const realPath = await fs.realpath(dirPath)
+        const realStats = await fs.stat(realPath)
+
+        if (realStats.isDirectory()) {
+          // シンボリックリンクがディレクトリを指している場合はOK
+          return
+        } else {
+          // シンボリックリンクがファイルを指している場合はエラー
+          throw new Error(`Path ${dirPath} exists as a symbolic link to a file, not a directory`)
+        }
+      } catch (error) {
+        // シンボリックリンクが壊れている場合
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(`Path ${dirPath} exists as a broken symbolic link`)
+        }
+        throw error
+      }
+    } else {
+      // ファイルとして存在している場合はエラー
+      throw new Error(`Path ${dirPath} exists as a file, not a directory`)
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // パスが存在しない場合は、ディレクトリを作成
+      await fs.mkdir(dirPath, { recursive: true })
+    } else {
+      // その他のエラーは再スロー
+      throw error
+    }
+  }
+}
+
+/**
+ * ディレクトリパスが有効かどうかをチェックする
+ * （ディレクトリまたはディレクトリへのシンボリックリンクである）
+ */
+export async function isValidDirectory(dirPath: string): Promise<boolean> {
+  try {
+    const stats = await fs.lstat(dirPath)
+
+    if (stats.isDirectory()) {
+      return true
+    }
+
+    if (stats.isSymbolicLink()) {
+      try {
+        const realPath = await fs.realpath(dirPath)
+        const realStats = await fs.stat(realPath)
+        return realStats.isDirectory()
+      } catch {
+        // 壊れたシンボリックリンク
+        return false
+      }
+    }
+
+    return false
+  } catch {
+    return false
+  }
+}

--- a/tests/commands/server-command.test.ts
+++ b/tests/commands/server-command.test.ts
@@ -5,6 +5,9 @@ import fs from 'fs/promises'
 import path from 'path'
 
 vi.mock('fs/promises')
+vi.mock('../../src/utils/directory.js', () => ({
+  ensureDirectoryExists: vi.fn(),
+}))
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({
     pid: 12345,
@@ -35,16 +38,16 @@ describe('ServerCommand', () => {
   describe('start command', () => {
     it('should start the server with default settings', async () => {
       vi.mocked(fs.access).mockRejectedValue(new Error('File not found'))
-      vi.mocked(fs.mkdir).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue()
+
+      const { ensureDirectoryExists } = await import('../../src/utils/directory.js')
+      vi.mocked(ensureDirectoryExists).mockResolvedValue()
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       await serverCommand.execute(['start'])
 
-      expect(vi.mocked(fs.mkdir)).toHaveBeenCalledWith(path.dirname(mockPidFile), {
-        recursive: true,
-      })
+      expect(vi.mocked(ensureDirectoryExists)).toHaveBeenCalledWith(path.dirname(mockPidFile))
       expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(mockPidFile, expect.any(String))
       expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(mockConfigFile, expect.any(String))
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Server started'))
@@ -71,8 +74,10 @@ describe('ServerCommand', () => {
 
     it('should accept custom port', async () => {
       vi.mocked(fs.access).mockRejectedValue(new Error('File not found'))
-      vi.mocked(fs.mkdir).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue()
+
+      const { ensureDirectoryExists } = await import('../../src/utils/directory.js')
+      vi.mocked(ensureDirectoryExists).mockResolvedValue()
 
       await serverCommand.execute(['start', '--port', '9000'])
 

--- a/tests/utils/directory.test.ts
+++ b/tests/utils/directory.test.ts
@@ -1,0 +1,159 @@
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { beforeEach, afterEach, describe, it, expect } from 'vitest'
+import { ensureDirectoryExists, isValidDirectory } from '../../src/utils/directory.js'
+
+describe('directory utilities', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `directory-test-${Date.now()}`)
+  })
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  describe('ensureDirectoryExists', () => {
+    it('should create directory if it does not exist', async () => {
+      const testDir = join(tempDir, 'new-dir')
+
+      await ensureDirectoryExists(testDir)
+
+      const stats = await fs.stat(testDir)
+      expect(stats.isDirectory()).toBe(true)
+    })
+
+    it('should not throw if directory already exists', async () => {
+      const testDir = join(tempDir, 'existing-dir')
+      await fs.mkdir(testDir, { recursive: true })
+
+      await expect(ensureDirectoryExists(testDir)).resolves.not.toThrow()
+
+      const stats = await fs.stat(testDir)
+      expect(stats.isDirectory()).toBe(true)
+    })
+
+    it('should work with nested directories', async () => {
+      const testDir = join(tempDir, 'nested', 'deep', 'directory')
+
+      await ensureDirectoryExists(testDir)
+
+      const stats = await fs.stat(testDir)
+      expect(stats.isDirectory()).toBe(true)
+    })
+
+    it('should throw error if path exists as a file', async () => {
+      const testFile = join(tempDir, 'test-file.txt')
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.writeFile(testFile, 'test content')
+
+      await expect(ensureDirectoryExists(testFile)).rejects.toThrow(
+        'exists as a file, not a directory'
+      )
+    })
+
+    it('should work with symbolic link pointing to directory', async () => {
+      const realDir = join(tempDir, 'real-dir')
+      const symLink = join(tempDir, 'sym-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.mkdir(realDir)
+      await fs.symlink(realDir, symLink)
+
+      await expect(ensureDirectoryExists(symLink)).resolves.not.toThrow()
+
+      const stats = await fs.lstat(symLink)
+      expect(stats.isSymbolicLink()).toBe(true)
+    })
+
+    it('should throw error if symbolic link points to file', async () => {
+      const realFile = join(tempDir, 'real-file.txt')
+      const symLink = join(tempDir, 'sym-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.writeFile(realFile, 'test content')
+      await fs.symlink(realFile, symLink)
+
+      await expect(ensureDirectoryExists(symLink)).rejects.toThrow(
+        'exists as a symbolic link to a file, not a directory'
+      )
+    })
+
+    it('should throw error if symbolic link is broken', async () => {
+      const symLink = join(tempDir, 'broken-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.symlink('/non-existent-path', symLink)
+
+      await expect(ensureDirectoryExists(symLink)).rejects.toThrow(
+        'exists as a broken symbolic link'
+      )
+    })
+  })
+
+  describe('isValidDirectory', () => {
+    it('should return true for existing directory', async () => {
+      const testDir = join(tempDir, 'test-dir')
+      await fs.mkdir(testDir, { recursive: true })
+
+      const result = await isValidDirectory(testDir)
+      expect(result).toBe(true)
+    })
+
+    it('should return false for non-existent path', async () => {
+      const testDir = join(tempDir, 'non-existent')
+
+      const result = await isValidDirectory(testDir)
+      expect(result).toBe(false)
+    })
+
+    it('should return false for file', async () => {
+      const testFile = join(tempDir, 'test-file.txt')
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.writeFile(testFile, 'test content')
+
+      const result = await isValidDirectory(testFile)
+      expect(result).toBe(false)
+    })
+
+    it('should return true for symbolic link pointing to directory', async () => {
+      const realDir = join(tempDir, 'real-dir')
+      const symLink = join(tempDir, 'sym-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.mkdir(realDir)
+      await fs.symlink(realDir, symLink)
+
+      const result = await isValidDirectory(symLink)
+      expect(result).toBe(true)
+    })
+
+    it('should return false for symbolic link pointing to file', async () => {
+      const realFile = join(tempDir, 'real-file.txt')
+      const symLink = join(tempDir, 'sym-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.writeFile(realFile, 'test content')
+      await fs.symlink(realFile, symLink)
+
+      const result = await isValidDirectory(symLink)
+      expect(result).toBe(false)
+    })
+
+    it('should return false for broken symbolic link', async () => {
+      const symLink = join(tempDir, 'broken-link')
+
+      await fs.mkdir(tempDir, { recursive: true })
+      await fs.symlink('/non-existent-path', symLink)
+
+      const result = await isValidDirectory(symLink)
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Enhance data directory creation to properly handle existing paths and symlinks.

This PR introduces a new utility function `ensureDirectoryExists` that replaces direct `fs.mkdir` calls. This function properly handles cases where the target path already exists as a directory or a symbolic link to a directory, and throws an error if it exists as a file or a broken/file-pointing symlink. This makes the application more robust against various file system states.